### PR TITLE
fixed test for Mac OS x

### DIFF
--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
@@ -2,6 +2,7 @@ package ca.cutterslade.gradle.helm
 
 import com.google.common.collect.Sets
 import com.google.common.io.MoreFiles
+import com.google.common.io.RecursiveDeleteOption
 import org.gradle.testkit.runner.GradleRunner
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe

--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
@@ -16,7 +16,7 @@ object HelmPluginNonSourceTasksSpec : Spek({
     it.toFile().writeText("plugins { id 'ca.cutterslade.helm' }".trimIndent())
   }
   afterGroup {
-    MoreFiles.deleteRecursively(projectDirectory)
+    MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
   }
 
   describe("The helm plugin") {


### PR DESCRIPTION
The recursive delete option fails on osx due to the  InsecureRecursiveDeleteException that gets thrown. This is because Mac OS does support symbolic links, but doesn't support  SecureDirectoryStream