### PR TITLE
fixed test for Mac OS

### DIFF
--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
@@ -1,6 +1,7 @@
 package ca.cutterslade.gradle.helm
 
 import com.google.common.io.MoreFiles
+import com.google.common.io.RecursiveDeleteOption
 import org.glassfish.grizzly.http.Method
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe

--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
@@ -41,7 +41,7 @@ object HelmPluginSimpleChartSpec : Spek({
   afterGroup {
     server().close()
     _server = null
-    MoreFiles.deleteRecursively(projectDirectory)
+    MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
   }
 
   describe("The helm plugin") {


### PR DESCRIPTION
The recursive delete option fails on osx due to the  InsecureRecursiveDeleteException that gets thrown. This is because Mac OS does support symbolic links, but doesn't support  SecureDirectoryStream.