### PR TITLE
Added handling for http proxy's

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,6 @@ For each chart configured in the build file, the plugin will create a set of tas
 | lint${chartName}Chart | Validate the chart by executing the 'helm lint' command. | `ca.cutterslade.gradle.helm.LintTask` |
 | package${chartName}Chart | Package the chart by executing the 'helm package' command. | `ca.cutterslade.gradle.helm.PackageTask` |
 | publish${chartName}Chart | Publish the chart to the configured repository. | `ca.cutterslade.gradle.helm.PublishTask` |
+
+## Proxy's
+The environment settings for `http_proxy`, `https_proxy` and `no_proxy` (case-insensitive) are respected.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,9 +41,13 @@ dependencies {
   compile(kotlin("reflect"))
   compile(gradleApi())
   compile("com.squareup.okhttp3:okhttp:3.10.0")
+  compile("io.github.microutils:kotlin-logging:1.5.4")
 
   testCompile(kotlin("test"))
   testCompile("org.jetbrains.spek:spek-junit-platform-engine:1.1.5")
+
+  // because the tests were alredy written using kotlintest
+  testCompile("io.kotlintest:kotlintest:2.0.7")
 
   add("functionalTestCompile", kotlin("test"))
   add("functionalTestCompile", "org.jetbrains.spek:spek-api:1.1.5")

--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginNonSourceTasksSpec.kt
@@ -2,22 +2,30 @@ package ca.cutterslade.gradle.helm
 
 import com.google.common.io.MoreFiles
 import com.google.common.io.RecursiveDeleteOption
+import mu.KotlinLogging
 import org.gradle.testkit.runner.GradleRunner
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
 object HelmPluginNonSourceTasksSpec : Spek({
+  val logger = KotlinLogging.logger {}
+
   val projectDirectory: Path = Files.createTempDirectory(HelmPluginNonSourceTasksSpec::class.simpleName)
   val buildFile = projectDirectory.resolve("build.gradle").also {
     it.toFile().writeText("plugins { id 'ca.cutterslade.helm' }")
   }
   afterGroup {
-    MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
+    try {
+      MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
+    } catch (e: FileSystemException) {
+      logger.warn(e) { "Unable to delete created test directory... this is a common issue on Windows because of it's file locking protocols" }
+    }
   }
 
   describe("The helm plugin") {

--- a/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
+++ b/src/functionalTest/kotlin/ca/cutterslade/gradle/helm/HelmPluginSimpleChartSpec.kt
@@ -2,10 +2,12 @@ package ca.cutterslade.gradle.helm
 
 import com.google.common.io.MoreFiles
 import com.google.common.io.RecursiveDeleteOption
+import mu.KotlinLogging
 import org.glassfish.grizzly.http.Method
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.assertEquals
@@ -13,6 +15,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 object HelmPluginSimpleChartSpec : Spek({
+  val logger = KotlinLogging.logger {}
+
   val projectName = "create-helm-chart-functional-test-build"
   val projectVersion = "0.1.0"
   val projectDirectory: Path = Files.createTempDirectory(HelmPluginSimpleChartSpec::class.simpleName)
@@ -57,7 +61,11 @@ object HelmPluginSimpleChartSpec : Spek({
   afterGroup {
     server().close()
     _server = null
-    MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
+    try {
+      MoreFiles.deleteRecursively(projectDirectory, RecursiveDeleteOption.ALLOW_INSECURE)
+    } catch (e: FileSystemException) {
+      logger.warn(e) { "Unable to delete created test directory... this is a common issue on Windows because of it's file locking protocols." }
+    }
   }
 
   fun String.task(chart: ChartBasics) = HelmPlugin.chartTaskName(this, chart.name)

--- a/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
+++ b/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
@@ -29,6 +29,7 @@ import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.withConvention
 import org.gradle.process.CommandLineArgumentProvider
 import java.io.File
+import java.net.Proxy
 import java.net.URL
 import java.nio.file.Files
 import java.util.concurrent.Callable
@@ -308,7 +309,13 @@ open class DownloadTask : DefaultTask() {
     val loc = location()
     loc.parentFile.mkdirs()
     if (!loc.isFile) {
-      URL(url()).openStream().use {
+      val socketAddress = HttpProxySettingsHandler().socketAddress
+      val proxy = if (socketAddress.isPresent) {
+        Proxy(Proxy.Type.HTTP, socketAddress.get())
+      } else {
+        Proxy.NO_PROXY
+      }
+      URL(url()).openConnection(proxy).inputStream.use {
         Files.copy(it, loc.toPath())
       }
     }

--- a/src/main/kotlin/ca/cutterslade/gradle/helm/HttpProxySettingsHandler.kt
+++ b/src/main/kotlin/ca/cutterslade/gradle/helm/HttpProxySettingsHandler.kt
@@ -1,0 +1,68 @@
+package ca.cutterslade.gradle.helm
+
+import mu.KLogging
+import java.net.InetSocketAddress
+import java.net.URI
+import java.net.URL
+import java.util.Arrays
+import java.util.Optional
+import java.util.Optional.of
+import java.util.TreeMap
+
+
+/**
+ * Reads both environment and system to pull all properties related to http(s) proxy and parses it into protocol, host, port and a no-proxy string.
+ */
+class HttpProxySettingsHandler @JvmOverloads constructor(
+    sys: CaseInsensitiveSystemDelegate = CaseInsensitiveSystemDelegate()
+) {
+
+  private companion object : KLogging()
+
+  val proxy: Optional<URL> = firstAvailable(sys["http_proxy"], sys["https_proxy"]).flatMap { this.tryParseUrl(it) }
+
+  val proxyProtocol: Optional<String> = proxy.flatMap { proxy -> of(proxy.protocol) }
+
+  val proxyHost: Optional<String> = proxy.flatMap { proxy -> of(proxy.host) }
+
+  val proxyPort: Optional<Int> = proxy.flatMap { proxy -> of(proxy.port) }
+
+  val noProxySettings: Optional<String> = sys["no_proxy"]
+
+  val isProxyIsConfigured: Boolean = proxy.isPresent
+
+  val socketAddress: Optional<InetSocketAddress> = proxy.flatMap { proxy -> of(InetSocketAddress(proxy.host, proxy.port)) }
+
+  private fun tryParseUrl(url: String): Optional<URL> =
+      try {
+        Optional.of(URI.create(url).toURL())
+      } catch (e: Exception) {
+        logger.warn(e) { "Failed to parse proxy url of '$url'" }
+        Optional.empty()
+      }
+
+
+  private fun firstAvailable(vararg options: Optional<String>) =
+      Arrays
+        .stream(options)
+        .filter { it.isPresent }
+        .findFirst()
+        .flatMap { it }
+
+
+}
+
+open class CaseInsensitiveSystemDelegate {
+  private val env = TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER)
+
+  init {
+    env.putAll(System.getenv())
+    System.getProperties().forEach { key, value -> env[key.toString()] = value.toString() }
+  }
+
+  operator fun get(name: String) = Optional.ofNullable(env[name])
+
+  protected open operator fun set(name: String, value: String) = env.put(name, value)
+
+  protected open fun clear() = env.clear()
+}

--- a/src/test/kotlin/ca/cutterslade/gradle/helm/HttpProxySettingsHandlerTest.kt
+++ b/src/test/kotlin/ca/cutterslade/gradle/helm/HttpProxySettingsHandlerTest.kt
@@ -1,0 +1,151 @@
+package ca.cutterslade.gradle.helm
+
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.FeatureSpec
+import java.net.URI
+import java.util.Optional
+
+// this class is using KotlinTest - it was already written this way, easier to just import kotlintest rather than translate to Spek.
+class HttpProxySettingsHandlerTest : FeatureSpec() {
+  init {
+    val testProxy = "http://myproxytest:8080"
+
+    feature("unset env variables shouldn't cause a problem") {
+      // given the environment variable
+      val mySys = MockSystemDelegate()
+      mySys.clear()
+
+      // when
+      val handler = HttpProxySettingsHandler(mySys)
+
+      // then
+      handler.proxy.isPresent shouldBe false
+      handler.proxyProtocol.isPresent shouldBe false
+      handler.proxyHost.isPresent shouldBe false
+      handler.proxyPort.isPresent shouldBe false
+      handler.noProxySettings.isPresent shouldBe false
+    }
+
+    feature("badly set HTTP_PROXY should cause 'not-present' on getHost() and getProxy()") {
+      // given
+      val mySys = MockSystemDelegate()
+      mySys.clear()
+      mySys["http_proxy"] = "some garbage"
+
+      // when
+      val handler = HttpProxySettingsHandler(mySys)
+
+      // then
+      handler.proxy.isPresent shouldBe false
+      handler.proxyHost.isPresent shouldBe false
+      handler.proxyPort.isPresent shouldBe false
+    }
+
+    feature("the simple proxy settings handler can read from environment properties and is not case sensitive") {
+
+      scenario("environment variable http_proxy is set") {
+        // given the environment variable
+        val mySys = MockSystemDelegate()
+        mySys["http_proxy"] = testProxy
+
+        // when
+        val handler = HttpProxySettingsHandler(mySys)
+
+        // then the proxy should be
+        handler.proxy shouldBe Optional.of(URI.create(testProxy).toURL())
+      }
+
+      scenario("system property http_proxy is set") {
+        // given
+        System.setProperty("http_proxy", testProxy)
+
+        // when (using the default system abstraction
+        val handler = HttpProxySettingsHandler()
+
+        // then
+        handler.proxy shouldBe Optional.of(URI.create(testProxy).toURL())
+      }
+    }
+
+    feature("the no_proxy settings are read from environment and system properties") {
+      val noProxy = "this,is,a,no,proxy"
+      scenario("environment variable no_proxy is set") {
+        // given the environment variable
+        val mySys = MockSystemDelegate()
+        mySys["no_proxy"] = noProxy
+
+        // when
+        val handler = HttpProxySettingsHandler(mySys)
+
+        // then
+        handler.noProxySettings shouldBe Optional.of(noProxy)
+      }
+
+      scenario("system property http_proxy is set") {
+        // given
+        System.setProperty("no_proxy", noProxy)
+
+        // when (using the default system abstraction
+        val handler = HttpProxySettingsHandler()
+
+        // then
+        handler.noProxySettings shouldBe Optional.of(noProxy)
+      }
+    }
+
+    feature("the proxy uri components are parsed from the proxy") {
+      scenario("parse scheme, host and port from full URI") {
+        // given the environment variable
+        val mySys = MockSystemDelegate()
+        mySys["http_proxy"] = testProxy
+
+        // when
+        val handler = HttpProxySettingsHandler(mySys)
+
+        // then the proxy should be
+        handler.proxyProtocol shouldBe Optional.of("http")
+        handler.proxyHost shouldBe Optional.of("myproxytest")
+        handler.proxyPort shouldBe Optional.of(8080)
+      }
+    }
+
+    feature("environment and system properties are case-insensitive") {
+      scenario("environment variable http_proxy is set with random case") {
+        // given the environment variable
+        val mySys = MockSystemDelegate()
+        mySys["HTTp_pROXy"] = testProxy
+
+        // when
+        val handler = HttpProxySettingsHandler(mySys)
+
+        // then the proxy should be
+        handler.proxy shouldBe Optional.of(URI.create(testProxy).toURL())
+      }
+
+      scenario("system property http_proxy is set with random case") {
+        // given
+        System.setProperty("HttP_PROXY", testProxy)
+
+        // when (using the default system abstraction
+        val handler = HttpProxySettingsHandler()
+
+        // then
+        handler.proxy shouldBe Optional.of(URI.create(testProxy).toURL())
+      }
+    }
+
+  }
+}
+
+/**
+ * Overrides the CaseInsensitiveSystemDelegate to make the setter and the clear functions public for test usage.
+ */
+class MockSystemDelegate : CaseInsensitiveSystemDelegate() {
+  public override fun set(name: String, value: String): String? {
+    return super.set(name, value)
+  }
+
+  public override fun clear() {
+    super.clear()
+  }
+}


### PR DESCRIPTION
added the HttpProxySettingsHandler, integrated and added the tests I already had for it - which use KotlinTest rather than Spek. Rather than re-write them though i just imported KotlinTest into the test compile tree.