### PR TITLE
Add custom task for adding Helm repositories

### DIFF
--- a/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
+++ b/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
@@ -13,6 +13,7 @@ import org.gradle.api.internal.AbstractTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
@@ -165,22 +166,22 @@ open class HelmPlugin : Plugin<Project> {
               taskChart = chart
               dependsOn(ensureNoChartTask, *verifyAndInitialize)
             }
-            val lintTask = create(chart.formatName(LINT_TASK_NAME_FORMAT), LintTask::class) {
-              desc("Validate the chart ${chart.name} using the helm lint command.")
-              taskChart = chart
-              dependsOn(sourceSet.processResourcesTaskName, *verifyAndInitialize)
-              tasks["check"].dependsOn(this)
-            }
             val updateTask = create(
-                chart.formatName(UPDATE_DEPENDENCIES_TASK_NAME_FORMAT),
-                UpdateDependenciesTask::class
+                    chart.formatName(UPDATE_DEPENDENCIES_TASK_NAME_FORMAT),
+                    UpdateDependenciesTask::class
             ) {
               desc("Update the chart ${chart.name} dependencies, populating the charts directory")
               taskChart = chart
               dependsOn(
-                  sourceSet.processResourcesTaskName,
-                  *verifyAndInitialize
+                      sourceSet.processResourcesTaskName,
+                      *verifyAndInitialize
               )
+            }
+            val lintTask = create(chart.formatName(LINT_TASK_NAME_FORMAT), LintTask::class) {
+              desc("Validate the chart ${chart.name} using the helm lint command.")
+              taskChart = chart
+              dependsOn(sourceSet.processResourcesTaskName, *verifyAndInitialize, updateTask)
+              tasks["check"].dependsOn(this)
             }
             val packageTask = create(chart.formatName(PACKAGE_TASK_NAME_FORMAT), PackageTask::class) {
               desc("Validate the chart ${chart.name} using the helm package command.")
@@ -585,5 +586,19 @@ open class UpdateDependenciesTask : HelmChartExecTask() {
             chart().toString()
         )
       }
+  )
+}
+
+open class AddRepositoryTask : SimpleHelmExecTask() {
+  @Input
+  val repositoryName: Property<String> = project.objects.property(String::class.java)
+
+  @Input
+  val repositoryUrl: Property<String> = project.objects.property(String::class.java)
+
+  override fun helmArgs(): List<CommandLineArgumentProvider> = listOf(
+    CommandLineArgumentProvider {
+      listOf("repo", "add", repositoryName.get(), repositoryUrl.get())
+    }
   )
 }

--- a/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
+++ b/src/main/kotlin/ca/cutterslade/gradle/helm/HelmPlugin.kt
@@ -167,14 +167,14 @@ open class HelmPlugin : Plugin<Project> {
               dependsOn(ensureNoChartTask, *verifyAndInitialize)
             }
             val updateTask = create(
-                    chart.formatName(UPDATE_DEPENDENCIES_TASK_NAME_FORMAT),
-                    UpdateDependenciesTask::class
+                chart.formatName(UPDATE_DEPENDENCIES_TASK_NAME_FORMAT),
+                UpdateDependenciesTask::class
             ) {
               desc("Update the chart ${chart.name} dependencies, populating the charts directory")
               taskChart = chart
               dependsOn(
-                      sourceSet.processResourcesTaskName,
-                      *verifyAndInitialize
+                  sourceSet.processResourcesTaskName,
+                  *verifyAndInitialize
               )
             }
             val lintTask = create(chart.formatName(LINT_TASK_NAME_FORMAT), LintTask::class) {


### PR DESCRIPTION
Rewire task dependencies so that dependencies are always updated before linting or packaging.

Provides a fix for https://github.com/wfhartford/gradle-helm/issues/24 and introduces a custom task for https://github.com/wfhartford/gradle-helm/issues/23. The new custom task is meant for creation by end users as needed. Not sure how to document the new task type. At the moment the documentation assume that there would be an instance created by this plugin.